### PR TITLE
Configure container image publishing to GitHub Container Registry

### DIFF
--- a/modules/api-gateway/build.gradle
+++ b/modules/api-gateway/build.gradle
@@ -39,14 +39,15 @@ dependencies {
 }
 
 bootBuildImage {
-    imageName = "simonjamesrowe/api-gateway:${version}"
+    imageName = "ghcr.io/simonjamesrowe/api-gateway:${version}"
     environment = [
         'BP_JVM_VERSION': '21'
     ]
     docker {
         publishRegistry {
-            username = System.getenv("DOCKER_USERNAME")
-            password = System.getenv("DOCKER_PASSWORD")
+            url = "https://ghcr.io"
+            username = System.getenv("GITHUB_ACTOR")
+            password = System.getenv("GITHUB_TOKEN")
         }
     }
 }

--- a/modules/search-service/build.gradle
+++ b/modules/search-service/build.gradle
@@ -24,14 +24,15 @@ dependencies {
 }
 
 bootBuildImage {
-    imageName = "simonjamesrowe/search-service:${version}"
+    imageName = "ghcr.io/simonjamesrowe/search-service:${version}"
     environment = [
         'BP_JVM_VERSION': '21'
     ]
     docker {
         publishRegistry {
-            username = System.getenv("DOCKER_USERNAME")
-            password = System.getenv("DOCKER_PASSWORD")
+            url = "https://ghcr.io"
+            username = System.getenv("GITHUB_ACTOR")
+            password = System.getenv("GITHUB_TOKEN")
         }
     }
 }


### PR DESCRIPTION
## Summary
Migrates Docker image publishing from Docker Hub to GitHub Container Registry (ghcr.io) for both api-gateway and search-service modules.

## Changes

### api-gateway
- Updated image name: `simonjamesrowe/api-gateway` → `ghcr.io/simonjamesrowe/api-gateway`
- Changed registry URL to `https://ghcr.io`
- Updated authentication to use `GITHUB_ACTOR` and `GITHUB_TOKEN` environment variables

### search-service
- Updated image name: `simonjamesrowe/search-service` → `ghcr.io/simonjamesrowe/search-service`
- Changed registry URL to `https://ghcr.io`
- Updated authentication to use `GITHUB_ACTOR` and `GITHUB_TOKEN` environment variables

## Environment Variables
To build and push images, set:
- `GITHUB_ACTOR` - Your GitHub username
- `GITHUB_TOKEN` - GitHub personal access token with `write:packages` permission

## Build Commands
```bash
# Build and push api-gateway image
./gradlew :modules:api-gateway:bootBuildImage --publishImage

# Build and push search-service image
./gradlew :modules:search-service:bootBuildImage --publishImage
```

## Benefits
- Better integration with GitHub workflows and Actions
- Free container hosting for public repositories
- Automatic cleanup policies
- Built-in vulnerability scanning