### PR TITLE
Fix Maven publishing validation errors

### DIFF
--- a/modules/component-test/build.gradle
+++ b/modules/component-test/build.gradle
@@ -66,6 +66,14 @@ publishing {
             from components.java
             groupId = 'com.simonjamesrowe'
             artifactId = 'component-test'
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionResult()
+                }
+            }
         }
     }
     repositories {
@@ -78,5 +86,9 @@ publishing {
             }
         }
     }
+}
+
+tasks.withType(GenerateModuleMetadata) {
+    suppressedValidationErrors.add('enforced-platform')
 }
 

--- a/modules/model/build.gradle
+++ b/modules/model/build.gradle
@@ -24,6 +24,14 @@ publishing {
             from components.java
             groupId = 'com.simonjamesrowe'
             artifactId = 'model'
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionResult()
+                }
+            }
         }
     }
     repositories {
@@ -36,4 +44,8 @@ publishing {
             }
         }
     }
+}
+
+tasks.withType(GenerateModuleMetadata) {
+    suppressedValidationErrors.add('enforced-platform')
 }


### PR DESCRIPTION
## Problem
The GitHub Actions workflow was failing with this error:
```
Invalid publication 'maven':
  - Publication only contains dependencies and/or constraints without a version.
```

## Solution
Added version mapping configuration to both `model` and `component-test` modules to publish resolved dependency versions instead of version-less dependencies.

## Changes
- Added `versionMapping` block to resolve dependency versions from runtime classpath
- Added suppression for `enforced-platform` validation errors
- Ensures published POMs contain complete version information

## Testing
This fix resolves the build failure in the main branch workflow when publishing to GitHub Packages.