### PR TITLE
Fix semantic versioning for GitHub Packages publishing

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set version without v prefix
+        id: version
+        run: echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
+        env:
+          TAG: ${{ steps.tag_version.outputs.new_tag }}
+
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:
@@ -41,22 +47,22 @@ jobs:
           body: ${{ steps.tag_version.outputs.changelog }}
 
       - name: Build with Gradle
-        run: ./gradlew clean build -Pversion=${{ steps.tag_version.outputs.new_version }} --no-daemon
+        run: ./gradlew clean build -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
 
       - name: Publish component-test and model to GitHub Packages
-        run: ./gradlew :modules:component-test:publish :modules:model:publish -Pversion=${{ steps.tag_version.outputs.new_version }} --no-daemon
+        run: ./gradlew :modules:component-test:publish :modules:model:publish -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish api-gateway Docker image
-        run: ./gradlew :modules:api-gateway:bootBuildImage --imageName=ghcr.io/simonjamesrowe/api-gateway:${{ steps.tag_version.outputs.new_version }} --publishImage -Pversion=${{ steps.tag_version.outputs.new_version }} --no-daemon
+        run: ./gradlew :modules:api-gateway:bootBuildImage --imageName=ghcr.io/simonjamesrowe/api-gateway:${{ steps.version.outputs.VERSION }} --publishImage -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish search-service Docker image
-        run: ./gradlew :modules:search-service:bootBuildImage --imageName=ghcr.io/simonjamesrowe/search-service:${{ steps.tag_version.outputs.new_version }} --publishImage -Pversion=${{ steps.tag_version.outputs.new_version }} --no-daemon
+        run: ./gradlew :modules:search-service:bootBuildImage --imageName=ghcr.io/simonjamesrowe/search-service:${{ steps.version.outputs.VERSION }} --publishImage -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,11 +70,11 @@ jobs:
       - name: Tag latest Docker images
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          docker pull ghcr.io/simonjamesrowe/api-gateway:${{ steps.tag_version.outputs.new_version }}
-          docker tag ghcr.io/simonjamesrowe/api-gateway:${{ steps.tag_version.outputs.new_version }} ghcr.io/simonjamesrowe/api-gateway:latest
+          docker pull ghcr.io/simonjamesrowe/api-gateway:${{ steps.version.outputs.VERSION }}
+          docker tag ghcr.io/simonjamesrowe/api-gateway:${{ steps.version.outputs.VERSION }} ghcr.io/simonjamesrowe/api-gateway:latest
           docker push ghcr.io/simonjamesrowe/api-gateway:latest
-          docker pull ghcr.io/simonjamesrowe/search-service:${{ steps.tag_version.outputs.new_version }}
-          docker tag ghcr.io/simonjamesrowe/search-service:${{ steps.tag_version.outputs.new_version }} ghcr.io/simonjamesrowe/search-service:latest
+          docker pull ghcr.io/simonjamesrowe/search-service:${{ steps.version.outputs.VERSION }}
+          docker tag ghcr.io/simonjamesrowe/search-service:${{ steps.version.outputs.VERSION }} ghcr.io/simonjamesrowe/search-service:latest
           docker push ghcr.io/simonjamesrowe/search-service:latest
 
       - name: Upload test results

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
     group = 'com.simonjamesrowe'
-    version = '0.0.1-SNAPSHOT'
+    version = project.findProperty('version') ?: '0.0.1-SNAPSHOT'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Problem
The workflow was failing with:
```
Could not PUT '...model/0.0.1-SNAPSHOT/...'. Received status code 422 from server: Unprocessable Entity
```

GitHub Packages does not accept SNAPSHOT versions, and the `-Pversion` parameter wasn't being properly applied.

## Root Causes
1. Root `build.gradle` had hardcoded version `0.0.1-SNAPSHOT` that wasn't respecting the `-Pversion` parameter
2. The git tag has a 'v' prefix (e.g., `v0.0.2`) which needed to be stripped for a clean semantic version

## Solution
1. **Updated `build.gradle`**: Changed version to respect the `-Pversion` parameter:
   ```gradle
   version = project.findProperty('version') ?: '0.0.1-SNAPSHOT'
   ```

2. **Added version stripping step**: Extract clean version number without 'v' prefix:
   ```yaml
   - name: Set version without v prefix
     run: echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
   ```

3. **Use clean version throughout**: All Gradle commands now use the clean semantic version (e.g., `0.0.2` instead of `v0.0.2` or `0.0.1-SNAPSHOT`)

## Testing
After merging, the workflow should successfully publish:
- Maven packages with proper semantic versions (e.g., `0.0.2`)
- Docker images tagged with semantic versions (e.g., `ghcr.io/simonjamesrowe/api-gateway:0.0.2`)