### PR TITLE
Add complete POM metadata for GitHub Packages publishing

### DIFF
--- a/modules/component-test/build.gradle
+++ b/modules/component-test/build.gradle
@@ -60,12 +60,44 @@ jar {
     enabled = true
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 publishing {
     publications {
         maven(MavenPublication) {
             from components.java
             groupId = 'com.simonjamesrowe'
             artifactId = 'component-test'
+
+            pom {
+                name = 'Component Test'
+                description = 'Shared test infrastructure with TestContainers for backend-modulith'
+                url = 'https://github.com/simonjamesrowe/backend-modulith'
+
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://opensource.org/licenses/MIT'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'simonjamesrowe'
+                        name = 'Simon Rowe'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/simonjamesrowe/backend-modulith.git'
+                    developerConnection = 'scm:git:ssh://github.com/simonjamesrowe/backend-modulith.git'
+                    url = 'https://github.com/simonjamesrowe/backend-modulith'
+                }
+            }
+
             versionMapping {
                 usage('java-api') {
                     fromResolutionOf('runtimeClasspath')

--- a/modules/model/build.gradle
+++ b/modules/model/build.gradle
@@ -18,12 +18,44 @@ jar {
     enabled = true
 }
 
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
 publishing {
     publications {
         maven(MavenPublication) {
             from components.java
             groupId = 'com.simonjamesrowe'
             artifactId = 'model'
+
+            pom {
+                name = 'Model'
+                description = 'Shared model and DTOs for backend-modulith'
+                url = 'https://github.com/simonjamesrowe/backend-modulith'
+
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://opensource.org/licenses/MIT'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'simonjamesrowe'
+                        name = 'Simon Rowe'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/simonjamesrowe/backend-modulith.git'
+                    developerConnection = 'scm:git:ssh://github.com/simonjamesrowe/backend-modulith.git'
+                    url = 'https://github.com/simonjamesrowe/backend-modulith'
+                }
+            }
+
             versionMapping {
                 usage('java-api') {
                     fromResolutionOf('runtimeClasspath')


### PR DESCRIPTION
## Problem
Still receiving 422 Unprocessable Entity errors when publishing to GitHub Packages:
```
Could not PUT 'https://maven.pkg.github.com/.../model/0.0.3/model-0.0.3.jar'
Received status code 422 from server: Unprocessable Entity
```

## Root Cause
GitHub Packages has strict requirements for Maven package metadata. The publications were missing required POM information.

## Solution
Added complete POM metadata to both `model` and `component-test` modules:

### Added to Publications:
1. **Sources and Javadoc JARs** - GitHub Packages expects these artifacts
   ```gradle
   java {
       withSourcesJar()
       withJavadocJar()
   }
   ```

2. **Complete POM Metadata**:
   - Project name and description
   - Project URL
   - License information (MIT)
   - Developer information
   - SCM (Source Control Management) details

### Why This Fixes the Issue
GitHub Packages validates Maven publications more strictly than other repositories. Missing metadata can cause rejection with a 422 error. By providing complete POM information including license, developers, and SCM, we ensure the packages meet GitHub's requirements.

## Testing
After merging, the workflow should successfully publish both packages to GitHub Packages with proper metadata.