### PR TITLE
Add debug logging for GitHub Packages publishing

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./gradlew clean build -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
 
       - name: Publish component-test and model to GitHub Packages
-        run: ./gradlew :modules:component-test:publish :modules:model:publish -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
+        run: ./gradlew :modules:component-test:publish :modules:model:publish -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon --info
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/modules/component-test/build.gradle
+++ b/modules/component-test/build.gradle
@@ -116,6 +116,7 @@ publishing {
                 username = System.getenv("GITHUB_ACTOR")
                 password = System.getenv("GITHUB_TOKEN")
             }
+            allowInsecureProtocol = false
         }
     }
 }

--- a/modules/model/build.gradle
+++ b/modules/model/build.gradle
@@ -74,6 +74,7 @@ publishing {
                 username = System.getenv("GITHUB_ACTOR")
                 password = System.getenv("GITHUB_TOKEN")
             }
+            allowInsecureProtocol = false
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added `--info` flag to the publish step for detailed error logging
- Added `allowInsecureProtocol = false` to ensure secure HTTPS connections

This will help diagnose the 422 Unprocessable Entity errors from GitHub Packages.

## Test plan
- [ ] Monitor the GitHub Actions workflow logs for detailed error messages
- [ ] Review any additional error details that appear with --info flag enabled