### PR TITLE
Use lowercase groupId for GitHub Packages compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 allprojects {
-    group = 'com.simonjamesrowe'
+    group = 'io.github.simonjamesrowe'
     version = project.findProperty('version') ?: '0.0.1-SNAPSHOT'
 
     repositories {

--- a/modules/component-test/build.gradle
+++ b/modules/component-test/build.gradle
@@ -69,7 +69,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             from components.java
-            groupId = 'com.simonjamesrowe'
+            groupId = 'io.github.simonjamesrowe'
             artifactId = 'component-test'
 
             pom {

--- a/modules/model/build.gradle
+++ b/modules/model/build.gradle
@@ -27,7 +27,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             from components.java
-            groupId = 'com.simonjamesrowe'
+            groupId = 'io.github.simonjamesrowe'
             artifactId = 'model'
 
             pom {


### PR DESCRIPTION
## Summary
- Changed groupId from `com.simonjamesrowe` to `io.github.simonjamesrowe`

GitHub Packages requires both groupId and artifactId to be all lowercase. The previous groupId contained an uppercase 'R' which was causing 422 Unprocessable Entity errors during publishing.

## Test plan
- [ ] Verify GitHub Actions build succeeds
- [ ] Confirm packages are successfully published to GitHub Packages