### PR TITLE
Use native ARM64 runners for multi-arch Docker builds

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,12 +5,16 @@ on:
       - master
       - main
 jobs:
-  build-test-and-deploy:
-    name: Build, Test and Deploy
+  build-test-and-version:
+    name: Build, Test and Version
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      changelog: ${{ steps.tag_version.outputs.changelog }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -46,16 +50,6 @@ jobs:
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
-
       - name: Build with Gradle
         run: ./gradlew clean build -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
 
@@ -65,60 +59,6 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and publish api-gateway Docker image (amd64)
-        run: ./gradlew :modules:api-gateway:bootBuildImage --imageName=ghcr.io/simonjamesrowe/api-gateway:${{ steps.version.outputs.VERSION }}-amd64 --publishImage -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and publish api-gateway Docker image (arm64)
-        run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          DOCKER_DEFAULT_PLATFORM=linux/arm64 ./gradlew :modules:api-gateway:bootBuildImage --imageName=ghcr.io/simonjamesrowe/api-gateway:${{ steps.version.outputs.VERSION }}-arm64 --publishImage -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create and push api-gateway multi-arch manifest
-        run: |
-          docker buildx imagetools create -t ghcr.io/simonjamesrowe/api-gateway:${{ steps.version.outputs.VERSION }} \
-            ghcr.io/simonjamesrowe/api-gateway:${{ steps.version.outputs.VERSION }}-amd64 \
-            ghcr.io/simonjamesrowe/api-gateway:${{ steps.version.outputs.VERSION }}-arm64
-
-      - name: Build and publish search-service Docker image (amd64)
-        run: ./gradlew :modules:search-service:bootBuildImage --imageName=ghcr.io/simonjamesrowe/search-service:${{ steps.version.outputs.VERSION }}-amd64 --publishImage -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and publish search-service Docker image (arm64)
-        run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          DOCKER_DEFAULT_PLATFORM=linux/arm64 ./gradlew :modules:search-service:bootBuildImage --imageName=ghcr.io/simonjamesrowe/search-service:${{ steps.version.outputs.VERSION }}-arm64 --publishImage -Pversion=${{ steps.version.outputs.VERSION }} --no-daemon
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create and push search-service multi-arch manifest
-        run: |
-          docker buildx imagetools create -t ghcr.io/simonjamesrowe/search-service:${{ steps.version.outputs.VERSION }} \
-            ghcr.io/simonjamesrowe/search-service:${{ steps.version.outputs.VERSION }}-amd64 \
-            ghcr.io/simonjamesrowe/search-service:${{ steps.version.outputs.VERSION }}-arm64
-
-      - name: Tag latest Docker images
-        run: |
-          docker buildx imagetools create -t ghcr.io/simonjamesrowe/api-gateway:latest \
-            ghcr.io/simonjamesrowe/api-gateway:${{ steps.version.outputs.VERSION }}
-          docker buildx imagetools create -t ghcr.io/simonjamesrowe/search-service:latest \
-            ghcr.io/simonjamesrowe/search-service:${{ steps.version.outputs.VERSION }}
-
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -127,3 +67,84 @@ jobs:
           path: |
             **/build/reports/tests/
             **/build/test-results/
+
+  build-docker-images:
+    name: Build Docker Images
+    needs: build-test-and-version
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        service: [api-gateway, search-service]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish Docker image
+        run: ./gradlew :modules:${{ matrix.service }}:bootBuildImage --imageName=ghcr.io/simonjamesrowe/${{ matrix.service }}:${{ needs.build-test-and-version.outputs.version }}-${{ matrix.arch }} --publishImage -Pversion=${{ needs.build-test-and-version.outputs.version }} --no-daemon
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  create-manifests:
+    name: Create Multi-Arch Manifests
+    needs: [build-test-and-version, build-docker-images]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push api-gateway multi-arch manifest
+        run: |
+          docker manifest create ghcr.io/simonjamesrowe/api-gateway:${{ needs.build-test-and-version.outputs.version }} \
+            ghcr.io/simonjamesrowe/api-gateway:${{ needs.build-test-and-version.outputs.version }}-amd64 \
+            ghcr.io/simonjamesrowe/api-gateway:${{ needs.build-test-and-version.outputs.version }}-arm64
+          docker manifest push ghcr.io/simonjamesrowe/api-gateway:${{ needs.build-test-and-version.outputs.version }}
+
+      - name: Create and push search-service multi-arch manifest
+        run: |
+          docker manifest create ghcr.io/simonjamesrowe/search-service:${{ needs.build-test-and-version.outputs.version }} \
+            ghcr.io/simonjamesrowe/search-service:${{ needs.build-test-and-version.outputs.version }}-amd64 \
+            ghcr.io/simonjamesrowe/search-service:${{ needs.build-test-and-version.outputs.version }}-arm64
+          docker manifest push ghcr.io/simonjamesrowe/search-service:${{ needs.build-test-and-version.outputs.version }}
+
+      - name: Tag latest Docker images
+        run: |
+          docker manifest create ghcr.io/simonjamesrowe/api-gateway:latest \
+            ghcr.io/simonjamesrowe/api-gateway:${{ needs.build-test-and-version.outputs.version }}-amd64 \
+            ghcr.io/simonjamesrowe/api-gateway:${{ needs.build-test-and-version.outputs.version }}-arm64
+          docker manifest push ghcr.io/simonjamesrowe/api-gateway:latest
+          docker manifest create ghcr.io/simonjamesrowe/search-service:latest \
+            ghcr.io/simonjamesrowe/search-service:${{ needs.build-test-and-version.outputs.version }}-amd64 \
+            ghcr.io/simonjamesrowe/search-service:${{ needs.build-test-and-version.outputs.version }}-arm64
+          docker manifest push ghcr.io/simonjamesrowe/search-service:latest


### PR DESCRIPTION
## Summary
- Restructured workflow to use native ARM64 GitHub runners instead of QEMU emulation
- Split workflow into 3 jobs: build/test/version, build Docker images (matrix), create manifests
- AMD64 images built on ubuntu-latest, ARM64 on ubuntu-24.04-arm
- Removed QEMU setup and emulation overhead

## Benefits
- Faster ARM64 builds (native vs emulated)
- More reliable builds
- Parallel execution of all 4 image builds (2 services × 2 architectures)
- Cleaner separation of concerns